### PR TITLE
fix: Fix retrieval reranker sorting issue

### DIFF
--- a/core/context/retrieval/pipelines/RerankerRetrievalPipeline.ts
+++ b/core/context/retrieval/pipelines/RerankerRetrievalPipeline.ts
@@ -107,7 +107,7 @@ export default class RerankerRetrievalPipeline extends BaseRetrievalPipeline {
       chunks.forEach((chunk, idx) => chunkIndexMap.set(chunk, idx));
 
       results.sort(
-        (a, b) => scores[chunkIndexMap.get(a)!] - scores[chunkIndexMap.get(b)!],
+        (a, b) => scores[chunkIndexMap.get(b)!] - scores[chunkIndexMap.get(a)!],
       );
       results = results.slice(-this.options.nFinal);
       return results;


### PR DESCRIPTION
## Description

The higher the score value of the reranker model, the higher the ranking should be

## Checklist

- [x] I've read the [contributing guide](https://github.com/continuedev/continue/blob/main/CONTRIBUTING.md)
- [x] The relevant docs, if any, have been updated or created
- [x] The relevant tests, if any, have been updated or created

